### PR TITLE
Support content with a colon

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -990,17 +990,18 @@ const i18n = function I18n(_OPTS = false) {
     let defaultSingular = singular
     let defaultPlural = plural
     if (objectNotation) {
-      let indexOfColon = singular.indexOf(':')
+      const separator = '::'
+      let indexOfColon = singular.indexOf(separator)
       // We compare against 0 instead of -1 because
-      // we don't really expect the string to start with ':'.
+      // we don't really expect the string to start with separator.
       if (indexOfColon > 0) {
-        defaultSingular = singular.substring(indexOfColon + 1)
+        defaultSingular = singular.substring(indexOfColon + separator.length)
         singular = singular.substring(0, indexOfColon)
       }
       if (plural && typeof plural !== 'number') {
-        indexOfColon = plural.indexOf(':')
+        indexOfColon = plural.indexOf(separator)
         if (indexOfColon > 0) {
-          defaultPlural = plural.substring(indexOfColon + 1)
+          defaultPlural = plural.substring(indexOfColon + separator.length)
           plural = plural.substring(0, indexOfColon)
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,23 @@
 {
-  "name": "i18n",
+  "name": "@metrica-sports/i18n",
+  "version": "1.0.0",
   "description": "lightweight translation module with dynamic json storage",
-  "version": "0.15.0",
-  "homepage": "http://github.com/mashpie/i18n-node",
   "repository": {
+    "type": "git",
+    "url": "http://github.com/metrica-sports/i18n-node.git"
+  },
+  "homepage": "http://github.com/mashpie/i18n-node",
+  "versionForked": "0.15.0",
+  "repositoryForked": {
     "type": "git",
     "url": "http://github.com/mashpie/i18n-node.git"
   },
   "author": "Marcus Spiegel <marcus.spiegel@gmail.com>",
   "funding": {
     "url": "https://github.com/sponsors/mashpie"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
   },
   "main": "./index",
   "files": [


### PR DESCRIPTION
Don't use single colon to find where an in-place translation starts because we could include translations with a colon or non-translated texts with it, e.g. Windows paths (`C:/Program Files/...`)